### PR TITLE
Added the dataminer item changes

### DIFF
--- a/include.lua
+++ b/include.lua
@@ -8,6 +8,7 @@ local includedScripts = {
     scriptsPath .. Actives .. "MegaBean",
     scriptsPath .. Actives .. "JarOfWisps",
     scriptsPath .. Actives .. "Abyss",
+    scriptsPath .. Actives .. "Dataminer",
 }
 
 for _, scripts in ipairs(includedScripts) do

--- a/resources/scripts/Actives/Dataminer.lua
+++ b/resources/scripts/Actives/Dataminer.lua
@@ -1,0 +1,33 @@
+local mod = RepPlusBalMod
+local itemPool = Game():GetItemPool()
+
+function mod:DataminerUse(player)
+
+    local player = Isaac.GetPlayer(0)
+    player:AddCollectible(CollectibleType.COLLECTIBLE_TMTRAINER)
+
+    local entities = Isaac:GetRoomEntities()
+
+    for i=1, #entities do
+        if entities[i].Type == EntityType.ENTITY_PICKUP then
+            if entities[i].Variant == PickupVariant.PICKUP_COLLECTIBLE then
+                if entities[i].SubType ~= 0 then
+                    entities[i]:ToPickup():Morph(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COLLECTIBLE, math.random(1000) + 1, true)
+                    while entities[i]:ToPickup().SubType == 25 do
+                        entities[i]:ToPickup():Morph(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COLLECTIBLE, math.random(1000) + 1, true)
+                    end
+                end
+            end
+        end
+    end
+
+    player:RemoveCollectible(CollectibleType.COLLECTIBLE_TMTRAINER)
+    
+    return {
+        Discharge = true,
+        Remove = false,
+        ShowAnim = true
+    }
+end
+
+mod:AddCallback(ModCallbacks.MC_USE_ITEM, mod.DataminerUse, CollectibleType.COLLECTIBLE_DATAMINER)


### PR DESCRIPTION
Using Dataminer in a room with item pedestals will now reroll them into glitched items. Sometimes the sprites appear invisible until the player comes back to the room because they are being rotated/moved from the normal dataminer effect. Repentance+ fixed this but I'm not sure how.