### PR TITLE
Implement Active Item Charge Buffs

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,5 +1,5 @@
 {	"runtime.version": "Lua 5.3",	"workspace.library": [
-		"c:\\Users\\Kotry\\.vscode\\extensions\\filloax.isaac-lua-api-vscode-1.11.2\\out\\emmylua\\repentogon"
+		"c:\\Users\\lokar\\.vscode\\extensions\\filloax.isaac-lua-api-vscode-1.11.2\\out\\emmylua\\repentogon"
 	],	"diagnostics.globals": [
 		"ActionTriggers",
 		"ActiveSlot",

--- a/include.lua
+++ b/include.lua
@@ -1,5 +1,6 @@
 local scriptsPath = "resources/scripts/"
 local Actives = "Actives/"
+local Passives = "Passives/"
 
 local includedScripts = {
     scriptsPath .. Actives .. "Flip",
@@ -8,6 +9,11 @@ local includedScripts = {
     scriptsPath .. Actives .. "MegaBean",
     scriptsPath .. Actives .. "JarOfWisps",
     scriptsPath .. Actives .. "Abyss",
+    scriptsPath .. Actives .. "ButterBean",
+    scriptsPath .. Actives .. "TheBean",
+    scriptsPath .. Actives .. "KidneyBean",
+
+    scriptsPath .. Passives .. "Jupiter",
 }
 
 for _, scripts in ipairs(includedScripts) do

--- a/resources/scripts/Actives/ButterBean.lua
+++ b/resources/scripts/Actives/ButterBean.lua
@@ -1,0 +1,4 @@
+local mod = RepPlusBalMod
+
+local config = Isaac.GetItemConfig():GetCollectible(CollectibleType.COLLECTIBLE_BUTTER_BEAN)
+config.MaxCharges = 60

--- a/resources/scripts/Actives/JarOfWisps.lua
+++ b/resources/scripts/Actives/JarOfWisps.lua
@@ -1,6 +1,10 @@
 local mod = RepPlusBalMod
 
-function mod:JarOfWispsCharge(collectible, player, var)
+local config = Isaac.GetItemConfig():GetCollectible(CollectibleType.COLLECTIBLE_JAR_OF_WISPS)
+config.MaxCharges = 6
+
+--[[ function mod:JarOfWispsCharge(collectible, player, var)
 	return 6
 end
 mod:AddCallback(ModCallbacks.MC_PLAYER_GET_ACTIVE_MAX_CHARGE, mod.JarOfWispsCharge, CollectibleType.COLLECTIBLE_JAR_OF_WISPS)
+ ]]

--- a/resources/scripts/Actives/KidneyBean.lua
+++ b/resources/scripts/Actives/KidneyBean.lua
@@ -1,0 +1,5 @@
+local mod = RepPlusBalMod
+
+local config = Isaac.GetItemConfig():GetCollectible(CollectibleType.COLLECTIBLE_KIDNEY_BEAN)
+config.ChargeType = 1
+config.MaxCharges = 120

--- a/resources/scripts/Actives/MegaBean.lua
+++ b/resources/scripts/Actives/MegaBean.lua
@@ -1,13 +1,17 @@
 local mod = RepPlusBalMod
 local game = Game()
-local room = game:GetRoom()
 
 function mod:TammysHeadRemoveAnim(_, _, player)
+    local room = game:GetRoom()
     room:MamaMegaExplosion(player.Position)
 end
 mod:AddCallback(ModCallbacks.MC_USE_ITEM, mod.TammysHeadRemoveAnim, CollectibleType.COLLECTIBLE_MEGA_BEAN)
 
-function mod:MegaBeanSixCharges()
+local config = Isaac.GetItemConfig():GetCollectible(CollectibleType.COLLECTIBLE_MEGA_BEAN)
+config.MaxCharges = 6
+
+--[[ function mod:MegaBeanSixCharges()
 	return 6
 end
 mod:AddCallback(ModCallbacks.MC_PLAYER_GET_ACTIVE_MAX_CHARGE, mod.MegaBeanSixCharges, CollectibleType.COLLECTIBLE_MEGA_BEAN)
+ ]]

--- a/resources/scripts/Actives/TheBean.lua
+++ b/resources/scripts/Actives/TheBean.lua
@@ -1,0 +1,5 @@
+local mod = RepPlusBalMod
+
+local config = Isaac.GetItemConfig():GetCollectible(CollectibleType.COLLECTIBLE_BEAN)
+config.ChargeType = 1
+config.MaxCharges = 120

--- a/resources/scripts/Actives/Void.lua
+++ b/resources/scripts/Actives/Void.lua
@@ -1,6 +1,10 @@
 local mod = RepPlusBalMod
 
-function mod:VoidFourCharges(collectible, player, var)
+local config = Isaac.GetItemConfig():GetCollectible(CollectibleType.COLLECTIBLE_VOID)
+config.MaxCharges = 4
+
+--[[ function mod:VoidFourCharges(collectible, player, var)
 	return 4
 end
 mod:AddCallback(ModCallbacks.MC_PLAYER_GET_ACTIVE_MAX_CHARGE, mod.VoidFourCharges, CollectibleType.COLLECTIBLE_VOID)
+ ]]

--- a/resources/scripts/Passives/Jupiter.lua
+++ b/resources/scripts/Passives/Jupiter.lua
@@ -1,0 +1,4 @@
+local mod = RepPlusBalMod
+
+local config = Isaac.GetItemConfig():GetCollectible(CollectibleType.COLLECTIBLE_JUPITER)
+config.AddHearts = 4


### PR DESCRIPTION
- Backported other items with changed charge values (Butter Bean, Kidney Bean, The Bean)
- Backported Jupiter HP change
- Fixed already implemented items with different charge values being overcharged/undercharged on pickup (Jar of Wisps, Mega Bean, Void), except Flip because special cases waaa